### PR TITLE
Adds `allow_empty` option to pass validation of empty enumerable values ...

### DIFF
--- a/lib/hydra/validations.rb
+++ b/lib/hydra/validations.rb
@@ -10,6 +10,14 @@ module Hydra
       include HelperMethods
     end
 
+    module ClassMethods
+      protected
+      # Overwrites ActiveModel::Validations::ClassMethods, adding :allow_empty
+      def _validates_default_keys
+        [:if, :unless, :on, :allow_blank, :allow_nil , :strict, :allow_empty]
+      end
+    end
+
   end
 end
 

--- a/lib/hydra/validations/enumerable_behavior.rb
+++ b/lib/hydra/validations/enumerable_behavior.rb
@@ -7,10 +7,18 @@ module Hydra
     # Behavior includes 'fixing' each error message to include the specific value
     # which was invalid.
     #
+    # `allow_empty` option can be used instead of `allow_blank` for greater
+    # clarity and precision with enumerable values. If a validator includes
+    # this mixin, then an empty enumerable value will always be invalid if
+    # `allow_empty` is false or nil.
+    #
     module EnumerableBehavior
 
       def validate_each(record, attribute, value)
-        if value.respond_to?(:each)
+        return super unless value.respond_to?(:each)
+        if value.respond_to?(:empty?) && value.empty?
+          record.errors.add(attribute, "can't be empty") unless options[:allow_empty]
+        else
           value.each do |v| 
             prev = record.errors[attribute].size rescue 0
             super(record, attribute, v)
@@ -19,8 +27,6 @@ module Hydra
               record.errors.add(attribute, fixed_message(v, messages.pop))
             end
           end
-        else
-          super
         end
       end
 

--- a/spec/support/shared_examples_for_validators.rb
+++ b/spec/support/shared_examples_for_validators.rb
@@ -31,3 +31,79 @@ shared_examples "it validates the single cardinality of a scalar attribute" do
     expect(subject).to be_valid
   end
 end
+
+shared_examples "an enumerable validator" do
+
+  let(:record) { record_class.new }
+
+  before do
+    record_class.validates attribute, opts
+    allow(record).to receive(attribute) { value }
+  end
+
+  context "when the value is nil" do
+    let(:value) { nil }
+    context "and `allow_nil` is true" do
+      let(:opts) { options.merge(allow_nil: true) }
+      it "should be valid" do
+        expect(record).to be_valid
+      end
+    end
+    context "and `allow_nil` is not true" do
+      let(:opts) { options }
+      it "should validate the value" do
+        expect_any_instance_of(described_class).to receive(:validate_each).with(record, attribute, value)
+        record.valid?
+      end
+    end
+  end
+
+  context "when the value is a blank scalar" do
+    let(:value) { "" }
+    context "and `allow_blank` is true" do
+      let(:opts) { options.merge(allow_blank: true) }
+      it "should be valid" do
+        expect(record).to be_valid
+      end
+    end
+    context "and `allow_blank` is not true" do
+      let(:opts) { options }
+      it "should validate the value" do
+        expect_any_instance_of(described_class).to receive(:validate_each).with(record, attribute, value)
+        record.valid?
+      end
+    end
+  end
+
+  context "when the value is is a non-blank scalar" do
+    let(:value) { "foo" }
+    let(:opts) { options }
+    it "should validate the value" do
+      expect_any_instance_of(described_class).to receive(:validate_each).with(record, attribute, value)
+      record.valid?
+    end
+  end
+
+  context "when the value is an empty enumerable" do
+    let(:value) { [] }
+    context "and `allow_blank` is true" do
+      let(:opts) { options.merge(allow_blank: true) }
+      it "should be valid" do
+        expect(record).to be_valid
+      end
+    end
+    context "and `allow_empty` is true" do
+      let(:opts) { options.merge(allow_empty: true) }
+      it "should be valid" do
+        expect(record).to be_valid
+      end
+    end
+    context "and neither `allow_blank` nor `allow_empty` is true" do
+      let(:opts) { options }
+      it "should be invalid" do
+        expect(record).to be_invalid
+      end
+    end
+  end
+
+end

--- a/spec/validators/format_validator_spec.rb
+++ b/spec/validators/format_validator_spec.rb
@@ -1,25 +1,28 @@
 require 'spec_helper'
+require 'support/shared_examples_for_validators'
 
 shared_examples "it validates the format of each member of the attribute value" do
   context "all attribute value members are valid" do
-    before { subject.field = ["foo", "bar"] }
+    before { record.field = ["foo", "bar"] }
     it "should be valid" do
-      expect(subject).to be_valid
+      expect(record).to be_valid
     end
   end
+
   context "one of the attribute value members is invalid" do
-    before { subject.field = ["foo1", "bar"] }
+    before { record.field = ["foo1", "bar"] }
     it "should be invalid" do
-      expect(subject).to be_invalid
+      expect(record).to be_invalid
     end
     it "should 'fix' the error message to include the value" do
-      subject.valid?
-      expect(subject.errors[:field]).to eq ["value \"foo1\" is invalid"]
+      record.valid?
+      expect(record.errors[:field]).to eq ["value \"foo1\" is invalid"]
     end
   end
 end
 
 describe Hydra::Validations::FormatValidator do
+
   before(:all) do
     class Validatable
       include ActiveModel::Validations
@@ -27,21 +30,32 @@ describe Hydra::Validations::FormatValidator do
       attr_accessor :field
     end
   end
+
   before(:each) { Validatable.clear_validators! }
+
   after(:all) { Object.send(:remove_const, :Validatable) }
-  subject { Validatable.new }
-  describe ".validates" do
-    before do
-      Validatable.clear_validators!
-      Validatable.validates :field, format: { with: /\A[[:alpha:]]+\Z/ }
+
+  describe "class methods" do
+    describe ".validates" do
+      before { Validatable.validates :field, format: { with: /\A[[:alpha:]]+\Z/ } }
+      it_behaves_like "it validates the format of each member of the attribute value" do
+        let(:record) { Validatable.new }
+      end
     end
-    it_behaves_like "it validates the format of each member of the attribute value"
   end
-  describe ".validates_format_of" do
-    before do
-      Validatable.clear_validators!
-      Validatable.validates_format_of :field, with: /\A[[:alpha:]]+\Z/
+  describe "helper methods" do
+    describe ".validates_format_of" do
+      before { Validatable.validates_format_of :field, with: /\A[[:alpha:]]+\Z/ }
+      it_behaves_like "it validates the format of each member of the attribute value" do
+        let(:record) { Validatable.new }
+      end
     end
-    it_behaves_like "it validates the format of each member of the attribute value"
   end
+
+  it_behaves_like "an enumerable validator" do
+    let(:options) { { format: { with: /\A[[:alpha:]]+\Z/ } } }
+    let(:record_class) { Validatable }
+    let(:attribute) { :field }
+  end
+
 end

--- a/spec/validators/inclusion_validator_spec.rb
+++ b/spec/validators/inclusion_validator_spec.rb
@@ -1,25 +1,30 @@
 require 'spec_helper'
+require 'support/shared_examples_for_validators'
 
 shared_examples "it validates the inclusion of each member of the attribute value" do
+
   context "all attribute value members are valid" do
-    before { subject.field = ["foo", "bar"] }
+    before { record.field = ["foo", "bar"] }
     it "should be valid" do
-      expect(subject).to be_valid
+      expect(record).to be_valid
     end
   end
+
   context "one of the attribute value members is invalid" do
-    before { subject.field = ["foo1", "bar"] }
+    before { record.field = ["foo1", "bar"] }
     it "should be invalid" do
-      expect(subject).to be_invalid
+      expect(record).to be_invalid
     end
     it "should 'fix' the error message to include the value" do
-      subject.valid?
-      expect(subject.errors[:field]).to eq ["value \"foo1\" is not included in the list"]
+      record.valid?
+      expect(record.errors[:field]).to eq ["value \"foo1\" is not included in the list"]
     end
   end
+
 end
 
 describe Hydra::Validations::InclusionValidator do
+
   before(:all) do
     class Validatable
       include ActiveModel::Validations
@@ -27,22 +32,31 @@ describe Hydra::Validations::InclusionValidator do
       attr_accessor :field
     end
   end
+
   before(:each) { Validatable.clear_validators! }
+
   after(:all) { Object.send(:remove_const, :Validatable) }
-  subject { Validatable.new }
+
   let(:valid_values) { ["foo", "bar", "baz"] }
+
   describe ".validates" do
-    before do
-      Validatable.clear_validators!
-      Validatable.validates :field, inclusion: { in: valid_values } 
+    before { Validatable.validates :field, inclusion: { in: valid_values } }
+    it_behaves_like "it validates the inclusion of each member of the attribute value" do
+      let(:record) { Validatable.new }
     end
-    it_behaves_like "it validates the inclusion of each member of the attribute value"
   end
+
   describe ".validates_inclusion_of" do
-    before do
-      Validatable.clear_validators!
-      Validatable.validates_inclusion_of :field, in: valid_values 
+    before { Validatable.validates_inclusion_of :field, in: valid_values }
+    it_behaves_like "it validates the inclusion of each member of the attribute value" do
+      let(:record) { Validatable.new }
     end
-    it_behaves_like "it validates the inclusion of each member of the attribute value"
   end
+
+  it_behaves_like "an enumerable validator" do
+    let(:options) { { inclusion: { in: valid_values } } }
+    let(:record_class) { Validatable }
+    let(:attribute) { :field }
+  end
+
 end


### PR DESCRIPTION
...with validators having EnumerableBehavior.

Empty enumerable value considered invalid by EnumerableBehavior unless `allow_empty` is true (`allow_blank: true` also works in the expected way).
Fixes #4
